### PR TITLE
🥸: Doesn't return a getter function (#4)

### DIFF
--- a/lib/createState.ts
+++ b/lib/createState.ts
@@ -25,7 +25,7 @@ import type { StateCallback, StateDestructor } from './types';
 function createState<T>(value: T): StateDestructor<T> {
 	const state = new State(value);
 
-	const getter = state;
+	const getter = () => state.get();
 	const setter: StateCallback<T> = newValue => state.set(newValue);
 
 	return [getter, setter, state];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,10 +6,12 @@ export interface StateObject<T> {
 	get(): T;
 }
 
+export type StateGetter<T> = () => T;
+
 export type StateCallback<T> = (newValue: T) => void;
 
 export type StateDestructor<T> = [
-	StateObject<T>,
+	StateGetter<T>,
 	StateCallback<T>,
 	StateObject<T>
 ];

--- a/tests/checkRegisterEffectCall.test.ts
+++ b/tests/checkRegisterEffectCall.test.ts
@@ -1,32 +1,37 @@
 import { createState, registerEffect } from '../lib/index';
 
 test('Check if registerEffect hook is being called', () => {
-	const [checker, setValue] = createState('default');
+	const [checker, setValue, checkerInstance] = createState('default');
 	const [hasCalled, setCalled] = createState(false);
 
 	registerEffect(() => {
 		setCalled(true);
-	}, [checker]);
+
+		console.log(`New value is ${checker()}`);
+	}, [checkerInstance]);
 
 	setValue('new value');
 
-	expect(hasCalled.get()).toEqual(true);
+	expect(hasCalled()).toEqual(true);
 });
 
 test('Check if registerEffect hook with multiple objects is called', () => {
-	const [checker, setValue] = createState('default');
-	const [checker2, setValue2] = createState('default');
+	const [checker, setValue, checkerInstance] = createState('default');
+	const [checker2, setValue2, checker2Instance] = createState('default');
 	const [hasCalled, setCalled] = createState(false);
 	const [hasCalled2, setCalled2] = createState(false);
 
 	registerEffect(() => {
 		setCalled(true);
 		setCalled2(true);
-	}, [checker, checker2]);
+
+		console.log(`New value is ${checker()}`);
+		console.log(`New value is ${checker2()}`);
+	}, [checkerInstance, checker2Instance]);
 
 	setValue('new value');
 	setValue2('new value - 2');
 
-	expect(hasCalled.get()).toEqual(true);
-	expect(hasCalled2.get()).toEqual(true);
+	expect(hasCalled()).toEqual(true);
+	expect(hasCalled2()).toEqual(true);
 });

--- a/tests/checkStateChanged.test.ts
+++ b/tests/checkStateChanged.test.ts
@@ -6,5 +6,5 @@ test('Check if state has been changed', () => {
 	const newValue = 'new value';
 	setValue(newValue);
 
-	expect(checker.get()).toEqual(newValue);
+	expect(checker()).toEqual(newValue);
 });

--- a/tests/resetState.test.ts
+++ b/tests/resetState.test.ts
@@ -9,5 +9,5 @@ test('Reset state', () => {
 	const finalNewValue = 'final value';
 	setValue(finalNewValue);
 
-	expect(checker.get()).toEqual(finalNewValue);
+	expect(checker()).toEqual(finalNewValue);
 });


### PR DESCRIPTION
Fixed a bug in the `createState` API which returned the state object instead of a getter function

Ref #4.