### PR TITLE
Add support for initial effect

### DIFF
--- a/lib/createState.ts
+++ b/lib/createState.ts
@@ -1,11 +1,21 @@
 import State from './State';
-import type { StateCallback, StateDestructor } from './types';
+import type {
+	StateCallback,
+	StateDestructor,
+	StateInitialEffect
+} from './types';
 
 /**
  * Creates a new state object and return an array with it's first value
  * as the getter and second value as an setter and the third as the instance
  * of the state. Instead of creating a new new instance of `State`, this
  * function should be used. Expects a default value.
+ *
+ * This function also let's you pass a inital effect callback function that
+ * will let you execute something when the state is initialised. This also
+ * passes in the initial value as the parameter to this function. This fixes
+ * the complexity of getting the initial value of the state before creating
+ * a variable to hold it's value. This behind the scenes solves a lot of complexity.
  *
  *
  * ```ts
@@ -18,12 +28,29 @@ import type { StateCallback, StateDestructor } from './types';
  * setChecked(true);
  * ```
  *
+ * **Using an initial effect:**
+ * ```ts
+ * const initialEffect = initialValue => console.log(`The website is ${initialValue ? 'Already loaded' : 'Not loaded yet!'}`);
+ *
+ *
+ * // You can pass in the initial effect as the second argument
+ * const [isLoaded, setLoaded] = createState(false, initialEffect);
+ * ```
+ *
  * @type {T} Generic type for the value
  * @param value {T} Default value for the state
+ * @param {StateInitialEffect<T>} initalEffect An initial effect function call for the state.
  * @returns {StateDestructor<T>} Returns a getter and a setter and the instance itself.
  */
-function createState<T>(value: T): StateDestructor<T> {
+function createState<T>(
+	value: T,
+	initalEffect?: StateInitialEffect<T>
+): StateDestructor<T> {
 	const state = new State(value);
+
+	if (typeof initalEffect !== 'undefined') {
+		initalEffect(state.get());
+	}
 
 	const getter = () => state.get();
 	const setter: StateCallback<T> = newValue => state.set(newValue);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,3 +15,5 @@ export type StateDestructor<T> = [
 	StateCallback<T>,
 	StateObject<T>
 ];
+
+export type StateInitialEffect<T> = (initialValue: T) => void;

--- a/tests/checkInitalEffectCall.test.ts
+++ b/tests/checkInitalEffectCall.test.ts
@@ -1,0 +1,21 @@
+import { createState } from '../lib/index';
+
+test('Check if the initial effect function is called', () => {
+	const [checker, setChecker] = createState(false);
+
+	createState('hello', () => {
+		setChecker(true);
+	});
+
+	expect(checker()).toEqual(true);
+});
+
+test('Check if the initial effect function is called and can access the initial value', () => {
+	const [checker, setChecker] = createState('');
+
+	createState('hello', newValue => {
+		setChecker(newValue);
+	});
+
+	expect(checker()).not.toBe('');
+});


### PR DESCRIPTION
This PR adds support for specifying a initial effect function to the `createState()` API.