### PR TITLE
Extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ setPrivacy(true);
 const [isPrivate, setPrivacy] = createState(false, initialValue => /* do something with the value */);
 ```
 
+#### `createStateWith()`
+
+Alternative to the `createState()` API but instead also adds support for extensibility of a custom state class. Althought the return value of this function is same as the `createState()` API, the function doesn't expect a value directly and instead the instance of the extended class. But you can pass the `initialEffect` as the second argument.
+
+```ts
+class CustomClass<T> extends State<T> {
+	...
+}
+
+const [data, setData] = createState(
+	new CustomClass(...),
+	initialValue => console.log(initialValue)
+);
+```
+
 #### `registerEffect()`
 
 Registers an effect for the state object specified in the argument. This function also supports specifying multiple state objects as arguments when you want to have a common state for multiple state objects.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ This will be available when the package is published.
 
 ### APIs
 
+### `State`
+
+The `State` class is the main API that powers all of the other APIs. You can create your own custom state class by extending this one. This API introduces a whole another world of possibilities and provides more flexibility and customasibility.
+
+```ts
+import { State } from 'statex';
+
+class CredentialsStore extends State<string> {
+	verifyValue(value: string) {
+		return value.length > 5;
+	}
+
+	// You can also override other methods like
+	get() {}
+	set() {}
+	onChange() {}
+
+	// You could also add some of your custom functions
+	// to organise your code.
+}
+```
+
 #### `createState()`
 
 Creates a new state object and return an array with it's first value as the getter and second value as an setter and the third as the instance of the state. Instead of creating a new new instance of `State`, this function should be used. Expects a default value in the first parameter.

--- a/lib/createStateWith.ts
+++ b/lib/createStateWith.ts
@@ -1,0 +1,43 @@
+import State from './State';
+import type {
+	ExtendedStateCallback,
+	ExtendedStateDestructor,
+	ExtendedStateInitialEffect,
+	ExtendedStateObject
+} from './types';
+import InstanceError from './errors/InstanceError';
+
+/**
+ * An alternative to `createState()` but supports using the custom extended State object
+ *
+ * @type {T} Generic type for the value
+ * @param {ExtendedStateObject<T>} extendedState extended state's instance
+ * @param {StateInitialEffect<T>} initalEffect An initial effect function call for the state.
+ * @returns {StateDestructor<T>} Returns a getter and a setter and the instance itself.
+ */
+function createStateWith<T>(
+	extendedState: ExtendedStateObject<T>,
+	initalEffect?: ExtendedStateInitialEffect<T>
+): ExtendedStateDestructor<T> {
+	// we don't have to create another instance, as the instance is passed in
+	// as the parameter `extendedState`. This allows more flexibility and
+	// customisability at the same time.
+
+	if (extendedState instanceof State) {
+		if (typeof initalEffect !== 'undefined') {
+			initalEffect(extendedState.get());
+		}
+
+		const getter = () => extendedState.get();
+		const setter: ExtendedStateCallback<T> = newValue =>
+			extendedState.set(newValue);
+
+		return [getter, setter, extendedState];
+	} else {
+		throw new InstanceError(
+			`${extendedState} is not an instance of the State class.`
+		);
+	}
+}
+
+export default createStateWith;

--- a/lib/errors/InstanceError.ts
+++ b/lib/errors/InstanceError.ts
@@ -1,0 +1,9 @@
+class InstanceError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'InstanceError';
+		this.message = message;
+	}
+}
+
+export default InstanceError;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,6 @@
+import State from './State';
 import createState from './createState';
+import createStateWith from './createStateWith';
 import registerEffect from './registerEffect';
 
-export { createState, registerEffect };
+export { State, createState, registerEffect, createStateWith };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,3 +17,18 @@ export type StateDestructor<T> = [
 ];
 
 export type StateInitialEffect<T> = (initialValue: T) => void;
+
+// extended state object types
+export type ExtendedStateObject<T> = StateObject<T>;
+
+export type ExtendedStateGetter<T> = () => T;
+
+export type ExtendedStateCallback<T> = (newValue: T) => void;
+
+export type ExtendedStateDestructor<T> = [
+	ExtendedStateGetter<T>,
+	ExtendedStateCallback<T>,
+	ExtendedStateObject<T>
+];
+
+export type ExtendedStateInitialEffect<T> = (initialValue: T) => void;

--- a/tests/checkExtensibility.test.ts
+++ b/tests/checkExtensibility.test.ts
@@ -1,0 +1,61 @@
+import { createStateWith, State } from '../lib';
+
+class ExtendedState extends State<string> {
+	constructor(value: string) {
+		super(value);
+		this.value = value;
+	}
+
+	verifyValue(newValue: string): boolean {
+		if (newValue.length < 3) {
+			return false;
+		}
+
+		return true;
+	}
+}
+
+test('Check if it supports extending the state', () => {
+	const [value, setter] = createStateWith(new ExtendedState('Hello'));
+
+	const newValue = 'World';
+	setter(newValue);
+
+	expect(value()).toBe('World');
+});
+
+class InvalidExtendedState {
+	value: string;
+
+	constructor(value: string) {
+		this.value = value;
+	}
+
+	verifyValue(newValue: string): boolean {
+		if (newValue.length < 3) {
+			return false;
+		}
+
+		return true;
+	}
+
+	get(): string {
+		return this.value;
+	}
+
+	set(newValue: string): void {
+		this.value = newValue;
+	}
+}
+
+test('Check if throws an error if the extended state is not an instance of State', () => {
+	try {
+		createStateWith(new InvalidExtendedState('Hello'));
+	} catch (e) {
+		expect(true).toEqual(true);
+
+		return;
+	}
+
+	expect(true).toBe(false); // fail if there is no error thrown
+});


### PR DESCRIPTION
This PR adds support for extending the existing `State` class with your custom version. This brings up a lot of flexibility and customisability within your state. This feature was build to be re-usable and the custom instance can be used anywhere. 